### PR TITLE
Add feature flag

### DIFF
--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -61,6 +61,7 @@ jobs:
           app-png: "qml/domeportpro/resources/images/DomeportPro.png"
           app-ico: "qml/domeportpro/resources/images/DomeportPro.ico"
           app-icns: "qml/domeportpro/resources/images/DomeportPro.icns"
+          app-environment: environment
           # Optional: macOS code signing (requires secrets to be set in repository)
           macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
           macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -72,6 +72,39 @@ jobs:
       - name: Upload packages
         uses: actions/upload-artifact@v4
         with:
+          name: domeportpro-basic-${{ matrix.artifact-name }}
+          path: packages/
+          retention-days: 30
+
+      - name: Package custom ossia score app
+        uses: ossia/actions/package-custom-app@master
+        with:
+          app-name: "Domeport Pro"
+          qml-files: "qml"
+          # Optional: Add your score file here
+          score-file: "score/app.score"
+          score-build-id: ${{ steps.score.outputs.artifact-id }}
+          platforms: "${{ matrix.platform }}"
+          # App metadata
+          app-organization: "SAT"
+          app-domain: "sat.qc.ca"
+          app-identifier: "ca.qc.sat.domeportpro"
+          app-description: "Domemaster / equirectangular content visualizer for dome and planetariums in 3D environment"
+          app-copyright: "Société des Arts Technologiques"
+          app-version: "1.0"
+          app-png: "qml/domeportpro/resources/images/DomeportPro.png"
+          app-ico: "qml/domeportpro/resources/images/DomeportPro.ico"
+          app-icns: "qml/domeportpro/resources/images/DomeportPro.icns"
+          # Optional: macOS code signing (requires secrets to be set in repository)
+          macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
+          macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
+          macos-notarize-team-id: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
+          macos-notarize-apple-id: ${{ secrets.MAC_NOTARIZE_APPLE_ID }}
+          macos-notarize-password: ${{ secrets.MAC_NOTARIZE_PASSWORD }}
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v4
+        with:
           name: domeportpro-${{ matrix.artifact-name }}
           path: packages/
           retention-days: 30
@@ -87,7 +120,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: all-packages
-          pattern: domeportpro-*
+          pattern: domeportpro-basic-*
           merge-multiple: true
 
       - name: Create Release (on tags)

--- a/environment
+++ b/environment
@@ -1,0 +1,1 @@
+export DOMEPORTPRO_BASIC=1

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -62,8 +62,15 @@ Window {
             }
         }
 
+        property bool basicFeatures: false
         property var modeList:
-            if (Qt.platform.os === "windows") {
+            if (basicFeatures) {
+                [
+                "Test pattern",
+                "Video playback",
+                ]
+            }
+            else if (Qt.platform.os === "windows") {
                 [
                 "Test pattern",
                 "Video playback",
@@ -424,6 +431,12 @@ Window {
     }
 
     function initialize() {
+        const domeportProBasic = Util.environmentVariable("DOMEPORTPRO_BASIC")
+        if (domeportProBasic) {
+            domeportModel.basicFeatures = true
+            console.log("Basic features enabled")
+        }
+
         Score.transport().play.connect(onPlay)
         Score.transport().stop.connect(onStop)
         Score.transport().pause.connect(onPause)


### PR DESCRIPTION
Add `DOMEPORTPRO_BASIC` environment variable to disable live input features (NDI, Spout and Syphon).

Publish basic package to tags and continuous.

Mac support for environment variables depends on fix https://github.com/ossia/score/pull/2002.

Closes https://github.com/sat-mtl/DomeportPro/issues/44