### PR TITLE
CI: also build on master/main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Domeport Pro
 
 on:
   pull_request:
-    branches: [ dev, develop ]
+    branches: [ dev, develop, master, main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/full-build.yml
+++ b/.github/workflows/full-build.yml
@@ -2,7 +2,7 @@ name: Full build Domeport Pro
 
 on:
   push:
-    branches: [ dev, develop ]
+    branches: [ dev, develop, master, main ]
     tags:
       - 'v*'
   workflow_dispatch:


### PR DESCRIPTION
`build.yml` only ran `pull_request` against `dev`/`develop`, and `full-build.yml` only pushed on `dev`/`develop` — so PRs into `master` and pushes to `master` got no CI (the other SAT apps build on any PR / on master pushes).

This adds `master` and `main` to:
- `build.yml` → `pull_request.branches`
- `full-build.yml` → `push.branches`

Release-job gating is left unchanged. With this in place, PRs targeting `master` (e.g. #60) build automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPndFPNSiqeVQNaRfufkUP)_