### PR TITLE
Restrict camera x axis to 180 degrees

### DIFF
--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -554,6 +554,16 @@ Window {
                     position.y = cameraHeight
                 }
             }
+
+            onEulerRotationChanged: {
+                // restrict up/down camera motion from -90 to 90 degrees
+                if (eulerRotation.x > 90) {
+                    eulerRotation.x = 90
+                }
+                if (eulerRotation.x < -90) {
+                    eulerRotation.x = -90
+                }
+            }
         }
 
         Model {


### PR DESCRIPTION
Restrict up/down camera motion from -90 to 90 degrees so that user cannot pivot to an inverted view.

Closes https://github.com/sat-mtl/DomeportPro/issues/56